### PR TITLE
Export transaction logs as part of main trx object

### DIFF
--- a/data/transaction.go
+++ b/data/transaction.go
@@ -74,6 +74,7 @@ type TransactionOnNetwork struct {
 	HyperBlockNonce  uint64                                `json:"hyperblockNonce"`
 	HyperBlockHash   string                                `json:"hyperblockHash"`
 	ScResults        []*transaction.ApiSmartContractResult `json:"smartContractResults,omitempty"`
+	Logs             *transaction.ApiLogs                  `json:"logs,omitempty"`
 }
 
 // TxCostResponseData follows the format of the data field of a transaction cost request


### PR DESCRIPTION
Currently, there's no way to get logs of specific transaction, though in gateway.elrond.com they returned on the same level as `smartContractResults`.
The field is just missing in struct