### PR TITLE
Update TransactionOnNetwork struct with missing fields

### DIFF
--- a/data/transaction.go
+++ b/data/transaction.go
@@ -68,8 +68,11 @@ type TransactionOnNetwork struct {
 	Signature        string                                `json:"signature"`
 	SourceShard      uint32                                `json:"sourceShard"`
 	DestinationShard uint32                                `json:"destinationShard"`
+	BlockNonce       uint64                                `json:"blockNonce"`
+	BlockHash        string                                `json:"blockHash"`
 	MiniblockType    string                                `json:"miniblockType"`
 	MiniblockHash    string                                `json:"miniblockHash"`
+	Timestamp        uint64                                `json:"timestamp"`
 	Status           string                                `json:"status"`
 	HyperBlockNonce  uint64                                `json:"hyperblockNonce"`
 	HyperBlockHash   string                                `json:"hyperblockHash"`


### PR DESCRIPTION
Hey,
According to JSON that returned from `gateway.elrond.com/transaction/:hash` some of the fields are missing.
I've added a couple that I'm personally needed atm.
Btw the Hash property is not populated at all, so I assume it doesn't make much sense to have it in struct too. I'm currently taking the `originalTxHash` from the `smartContractResults` is that the proper way to get the transaction hash?
Thanks,
Regards