### PR TITLE
added tx hash computation feature

### DIFF
--- a/builders/errors.go
+++ b/builders/errors.go
@@ -16,3 +16,6 @@ var ErrInvalidAddress = errors.New("invalid address handler")
 
 // ErrNilTxSigner signals that a nil transaction signer was provided
 var ErrNilTxSigner = errors.New("nil transaction signer")
+
+// ErrMissingSignature signals that a transaction's signature is empty when trying to compute it's hash
+var ErrMissingSignature = errors.New("missing signature when computing the transaction's hash")

--- a/builders/txBuilder.go
+++ b/builders/txBuilder.go
@@ -88,28 +88,26 @@ func (builder *txBuilder) ApplySignatureAndGenerateTx(
 	return builder.createTransaction(arg), nil
 }
 
-// ApplySignatureAndGenerateTxHash will sign the transaction and return it's hash
-func (builder *txBuilder) ApplySignatureAndGenerateTxHash(
-	skBytes []byte,
-	arg data.ArgCreateTransaction,
-) ([]byte, *data.Transaction, error) {
-	signedTx, err := builder.ApplySignatureAndGenerateTx(skBytes, arg)
-	if err != nil {
-		return nil, nil, err
+// ComputeTxHash will return the hash of the provided transaction. It assumes that the transaction is already signed,
+// otherwise it will return an error.
+// The input can be the result of the ApplySignatureAndGenerateTx function
+func (builder *txBuilder) ComputeTxHash(tx *data.Transaction) ([]byte, error) {
+	if len(tx.Signature) == 0 {
+		return nil, ErrMissingSignature
 	}
 
-	nodeTx, err := transactionToNodeTransaction(signedTx)
+	nodeTx, err := transactionToNodeTransaction(tx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	txBytes, err := nodeInternalMarshaller.Marshal(nodeTx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	txHash := blake2bHasher.Compute(string(txBytes))
-	return txHash, signedTx, nil
+	return txHash, nil
 }
 
 func transactionToNodeTransaction(tx *data.Transaction) (*transaction.Transaction, error) {

--- a/builders/txBuilder_test.go
+++ b/builders/txBuilder_test.go
@@ -110,3 +110,59 @@ func TestTxBuilder_ApplySignatureAndGenerateTx(t *testing.T) {
 			tx.Signature)
 	})
 }
+
+func TestTxBuilder_ApplySignatureAndGenerateTxHash(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fails if signing fails", func(t *testing.T) {
+		t.Parallel()
+
+		sk, err := hex.DecodeString("6ae10fed53a84029e53e35afdbe083688eea0917a09a9431951dd42fd4da14c40d248169f4dd7c90537f05be1c49772ddbf8f7948b507ed17fb23284cf218b7d")
+		require.Nil(t, err)
+
+		args := data.ArgCreateTransaction{
+			Value:    "100",
+			RcvAddr:  "erd1l20m7kzfht5rhdnd4zvqr82egk7m4nvv3zk06yw82zqmrt9kf0zsf9esqq",
+			GasPrice: 10,
+			GasLimit: 100000,
+			Data:     []byte(""),
+			ChainID:  "integration test chain id",
+			Version:  uint32(1),
+		}
+		expectedErr := errors.New("expected error")
+		tb, _ := NewTxBuilder(&testsCommon.TxSignerStub{
+			SignMessageCalled: func(msg []byte, skBytes []byte) ([]byte, error) {
+				return nil, expectedErr
+			},
+		})
+
+		txHash, tx, errGenerate := tb.ApplySignatureAndGenerateTxHash(sk, args)
+		assert.Nil(t, tx)
+		assert.Nil(t, txHash)
+		assert.Equal(t, expectedErr, errGenerate)
+	})
+
+	t.Run("should generate tx hash", func(t *testing.T) {
+		t.Parallel()
+
+		sk, err := hex.DecodeString("28654d9264f55f18d810bb88617e22c117df94fa684dfe341a511a72dfbf2b68")
+		require.Nil(t, err)
+
+		args := data.ArgCreateTransaction{
+			Nonce:    1,
+			Value:    "11500313000000000000",
+			RcvAddr:  "erd1p72ru5zcdsvgkkcm9swtvw2zy5epylwgv8vwquptkw7ga7pfvk7qz7snzw",
+			GasPrice: 1000000000,
+			GasLimit: 60000,
+			Data:     []byte(""),
+			ChainID:  "T",
+			Version:  uint32(1),
+		}
+		tb, _ := NewTxBuilder(blockchain.NewTxSigner())
+
+		txHash, tx, errGenerate := tb.ApplySignatureAndGenerateTxHash(sk, args)
+		assert.Nil(t, errGenerate)
+		assert.Equal(t, "725c6aa7def724c60f02ee481734807038fef125e453242bf4dc570fc4a4f2ff1b78e996a2ec67ef8be03f9b98b0251d419cfc72c6e6c5c9e33f879af938f008", tx.Signature)
+		assert.Equal(t, "8bbb2b7474deb2e67fa8f9db1eccef57ec14aa93710452a5de5ff52e5a369144", hex.EncodeToString(txHash))
+	})
+}


### PR DESCRIPTION
Added `ApplySignatureAndGenerateTxHash` function for txBuilder.
It is not yet included in any interface, but the functionality is there whenever needed - the client can add the new function to its interface whenever needed