### PR TITLE
Wallet interactors: export functions, allow new key generation flow

### DIFF
--- a/interactors/wallet.go
+++ b/interactors/wallet.go
@@ -96,6 +96,13 @@ func (w *wallet) GenerateMnemonic() (data.Mnemonic, error) {
 
 // GetPrivateKeyFromMnemonic generates a private key based on mnemonic, account and address index
 func (w *wallet) GetPrivateKeyFromMnemonic(mnemonic data.Mnemonic, account, addressIndex uint32) []byte {
+	seed := w.CreateSeedFromMnemonic(mnemonic)
+	privateKey := w.GetPrivateKeyFromSeed(seed, account, addressIndex)
+	return privateKey
+}
+
+// GetPrivateKeyFromSeed generates a private key based on seed, account and address index
+func (w *wallet) GetPrivateKeyFromSeed(seed []byte, account, addressIndex uint32) []byte {
 	var egldPath = bip32Path{
 		44 | hardened,
 		egldCoinType | hardened,
@@ -104,12 +111,17 @@ func (w *wallet) GetPrivateKeyFromMnemonic(mnemonic data.Mnemonic, account, addr
 		hardened, // addressIndex
 	}
 
-	seed := bip39.NewSeed(string(mnemonic), "")
 	egldPath[2] = account | hardened
 	egldPath[4] = addressIndex | hardened
 	keyData := derivePrivateKey(seed, egldPath)
 
 	return keyData.Key
+}
+
+// GetSeedFromMnemonic creates a seed for a given mnemonic
+func (w *wallet) CreateSeedFromMnemonic(mnemonic data.Mnemonic) []byte {
+	seed := bip39.NewSeed(string(mnemonic), "")
+	return seed
 }
 
 func derivePrivateKey(seed []byte, path bip32Path) *bip32 {

--- a/interactors/wallet_test.go
+++ b/interactors/wallet_test.go
@@ -36,6 +36,22 @@ func TestWallet_GetPrivateKeyFromMnemonic(t *testing.T) {
 	assert.Equal(t, expectedHexPrivKey, hex.EncodeToString(privKey))
 }
 
+func TestWallet_CreateSeedFromMnemonicThenGetPrivateKeyFromSeed(t *testing.T) {
+	t.Parallel()
+
+	w := NewWallet()
+	mnemonic := data.Mnemonic("acid twice post genre topic observe valid viable gesture fortune funny dawn around blood enemy page update reduce decline van bundle zebra rookie real")
+	seed := w.CreateSeedFromMnemonic(mnemonic)
+
+	privKey := w.GetPrivateKeyFromSeed(seed, 0, 0)
+	expectedHexPrivKey := "0b7966138e80b8f3bb64046f56aea4250fd7bacad6ed214165cea6767fd0bc2c"
+	assert.Equal(t, expectedHexPrivKey, hex.EncodeToString(privKey))
+
+	privKey = w.GetPrivateKeyFromSeed(seed, 0, 1)
+	expectedHexPrivKey = "1648ad209d6b157a289884933e3bb30f161ec7113221ec16f87c3578b05830b0"
+	assert.Equal(t, expectedHexPrivKey, hex.EncodeToString(privKey))
+}
+
 func TestWallet_GetAddressFromMnemonicWalletIntegration(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Allow one to generate keys by invoking `CreateSeedFromMnemonic(mnemonic)` first, then invoking `GetPrivateKeyFromSeed(seed)`. This is useful when deriving more keys from a single mnemonic: seed can be computed once, then reused (significant optimization, since creating the `seed` is a costly part of HD-deriving a secret key).